### PR TITLE
Factor out server roles names and deduplicate code

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -71,6 +71,18 @@ trait SystemVariableService {
   ) : Box[Map[String, Variable]]
 }
 
+
+final case class RudderServerRole(
+    val name       : String
+  , val configValue: String
+)
+
+final case class ResolvedRudderServerRole(
+    val name       : String
+  , val configValue: Option[Iterable[String]]
+)
+
+
 class SystemVariableServiceImpl(
     licenseRepository: LicenseRepository
   , systemVariableSpecService: SystemVariableSpecService
@@ -84,13 +96,7 @@ class SystemVariableServiceImpl(
   , webdavPassword           : String
   , syslogPort               : Int
   , configurationRepository  : String
-  , rudderServerRoleLdap     : String
-  , rudderServerRoleInventoryEndpoint: String
-  , rudderServerRoleDb       : String
-  , rudderServerRoleRelayTop : String
-  , rudderServerRoleWeb      : String
-  , rudderServerRolePromisesOnlyRelay    : String
-  , rudderServerRoleCFEngineMissionPortal: String
+  , serverRoles              : Seq[RudderServerRole]
   //denybadclocks and skipIdentify are runtime properties
   , getDenyBadClocks: () => Box[Boolean]
   , getSkipIdentify : () => Box[Boolean]
@@ -126,13 +132,7 @@ class SystemVariableServiceImpl(
     }
   }
 
-  lazy val definedRudderServerRoleLdap     = parseRoleContent(rudderServerRoleLdap)
-  lazy val definedRudderServerRoleDb       = parseRoleContent(rudderServerRoleDb)
-  lazy val definedRudderServerRoleRelayTop = parseRoleContent(rudderServerRoleRelayTop)
-  lazy val definedRudderServerRoleWeb      = parseRoleContent(rudderServerRoleWeb)
-  lazy val definedRudderServerRoleInventoryEnpoint      = parseRoleContent(rudderServerRoleInventoryEndpoint)
-  lazy val definedRudderServerRolePromisesOnlyRelay     = parseRoleContent(rudderServerRolePromisesOnlyRelay)
-  lazy val definedRudderServerRoleCFEngineMissionPortal = parseRoleContent(rudderServerRoleCFEngineMissionPortal)
+  lazy val defaultServerRoles = serverRoles.map( x => ResolvedRudderServerRole(x.name, parseRoleContent(x.configValue)))
 
   // compute all the global system variable (so that need to be computed only once in a deployment)
 
@@ -215,49 +215,16 @@ class SystemVariableServiceImpl(
     val varRoleMappingValue = if (nodeConfigurationRoles.size > 0) {
       val allNodeInfosSet = allNodeInfos.values.toSet
 
-      val nodesWithRoleLdap = definedRudderServerRoleLdap match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-ldap"))
+      val roles = defaultServerRoles.map { case ResolvedRudderServerRole(name, optValue) =>
+        val nodeValue = optValue match {
+          case Some(seq) => seq
+          case None      => getNodesWithRole(allNodeInfosSet, ServerRole(name))
+        }
+        writeNodesWithRole(nodeValue, name)
       }
 
-      val nodesWithRoleInventoryEndpoint = definedRudderServerRoleInventoryEnpoint match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-inventory-endpoint"))
-      }
-
-      val nodesWithRoleDb = definedRudderServerRoleDb match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-db"))
-      }
-
-      val nodesWithRoleRelayTop = definedRudderServerRoleRelayTop match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-relay-top"))
-      }
-
-      val nodesWithRoleWeb = definedRudderServerRoleWeb match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-web"))
-      }
-      
-      val nodesWithRolePromisesOnlyRelay = definedRudderServerRolePromisesOnlyRelay match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-promises-only-relay"))
-      }
-            
-      val nodesWithRoleCFEngineMissionPortal = definedRudderServerRoleCFEngineMissionPortal match {
-        case Some(seq) => seq
-        case None => getNodesWithRole(allNodeInfosSet, ServerRole("rudder-cfengine-mission-portal"))
-      }
-
-      
-      writeNodesWithRole(nodesWithRoleLdap, "rudder-ldap") +
-      writeNodesWithRole(nodesWithRoleInventoryEndpoint, "rudder-inventory-endpoint") +
-      writeNodesWithRole(nodesWithRoleDb, "rudder-db") +
-      writeNodesWithRole(nodesWithRoleRelayTop, "rudder-relay-top") +
-      writeNodesWithRole(nodesWithRoleWeb, "rudder-web") +
-      writeNodesWithRole(nodesWithRolePromisesOnlyRelay, "rudder-promises-only-relay") +
-      writeNodesWithRole(nodesWithRoleCFEngineMissionPortal, "rudder-cfengine-mission-portal")
+      //build the final string
+      (""/:roles) { (x,y) => x + y }
     } else {
       ""
     }

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -311,14 +311,16 @@ object RudderConfig extends Loggable {
   val RUDDER_DEBUG_NODE_CONFIGURATION_PATH = config.getString("rudder.debug.nodeconfiguration.path")
 
   // Roles definitions
-  val RUDDER_SERVER_ROLES_LDAP                    = config.getString("rudder.server-roles.ldap")
-  val RUDDER_SERVER_ROLES_INVENTORY_ENDPOINT      = config.getString("rudder.server-roles.inventory-endpoint")
-  val RUDDER_SERVER_ROLES_DB                      = config.getString("rudder.server-roles.db")
-  val RUDDER_SERVER_ROLES_FRONT                   = config.getString("rudder.server-roles.relay-top")
-  val RUDDER_SERVER_ROLES_WEBAPP                  = config.getString("rudder.server-roles.web")
-  val RUDDER_SERVER_ROLES_PROMISES_ONLY_RELAY     = config.getString("rudder.server-roles.relay-promises-only")
-  val RUDDER_SERVER_ROLES_CFENGINE_MISSION_PORTAL = config.getString("rudder.server-roles.cfengine-mission-portal")
-  
+  val RUDDER_SERVER_ROLES = Seq(
+      //each time, it's (role name, key in the config file)
+      RudderServerRole("rudder-ldap", "rudder.server-roles.ldap")
+    , RudderServerRole("rudder-inventory-endpoint", "rudder.server-roles.inventory-endpoint")
+    , RudderServerRole("rudder-db", "rudder.server-roles.db")
+    , RudderServerRole("rudder-relay-top", "rudder.server-roles.relay-top")
+    , RudderServerRole("rudder-web", "rudder.server-roles.web")
+    , RudderServerRole("rudder-promises-only-relay", "rudder.server-roles.relay-promises-only")
+    , RudderServerRole("rudder-cfengine-mission-portal", "rudder.server-roles.cfengine-mission-portal")
+  )
 
   val licensesConfiguration = "licenses.xml"
   val logentries = "logentries.xml"
@@ -1313,13 +1315,7 @@ object RudderConfig extends Loggable {
     , RUDDER_WEBDAV_PASSWORD
     , RUDDER_SYSLOG_PORT
     , RUDDER_DIR_GITROOT
-    , RUDDER_SERVER_ROLES_LDAP
-    , RUDDER_SERVER_ROLES_INVENTORY_ENDPOINT
-    , RUDDER_SERVER_ROLES_DB
-    , RUDDER_SERVER_ROLES_FRONT
-    , RUDDER_SERVER_ROLES_WEBAPP
-    , RUDDER_SERVER_ROLES_PROMISES_ONLY_RELAY
-    , RUDDER_SERVER_ROLES_CFENGINE_MISSION_PORTAL
+    , RUDDER_SERVER_ROLES
     , configService.cfengine_server_denybadclocks _
     , configService.cfengine_server_skipidentify _
     , configService.agent_run_interval


### PR DESCRIPTION
I propose the following factorisation of the code so that we limit the number of lazy val (heavy object with locks etc) and are able the simply add new roles with just a couple of String in a RudderServerRole in AppConfig.
