### PR TITLE
Simplify NodeStatusReport, avoid allocation

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -211,10 +211,18 @@ object Doobie {
     )
   }
 
+  implicit val SetRuleNodeStatusReportComposite: Composite[Set[RuleNodeStatusReport]] = {
+    import NodeStatusReportSerialization._
+    Composite[String].imap(
+        json => throw new RuntimeException(s"You can't deserialize a set of RuleNodeStatusReport for now"))(
+        x    => x.toCompactJson
+    )
+  }
+
   implicit val AggregatedStatusReportComposite: Composite[AggregatedStatusReport] = {
     import NodeStatusReportSerialization._
     Composite[String].imap(
-        json => throw new RuntimeException(s"You can deserialize aggredatedStatusReport for now"))(
+        json => throw new RuntimeException(s"You can't deserialize aggredatedStatusReport for now"))(
         x    => x.toCompactJson
     )
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -783,7 +783,7 @@ object ExecutionBatch extends Loggable {
       case _                          => Nil
     }
 
-    NodeStatusReport.applyByNode(nodeId, runInfo, status, overrides, ruleNodeStatusReports)
+    NodeStatusReport.apply(nodeId, runInfo, status, overrides, ruleNodeStatusReports)
   }
 
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -101,7 +101,7 @@ trait ReportingService {
       val n1 = System.currentTimeMillis
       val result = reports.mapValues { status =>
         NodeStatusReport.filterByRules(status, ruleIds)
-      }.filter { case (k,v) => v.report.reports.nonEmpty || v.overrides.nonEmpty }
+      }.filter { case (k,v) => v.reports.nonEmpty || v.overrides.nonEmpty }
       val n2 = System.currentTimeMillis
       TimingDebugLogger.trace(s"Filter Node Status Reports on ${ruleIds.size} in : ${n2 - n1}ms")
       result

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -65,7 +65,7 @@ object ReportingServiceUtils {
    * Build rule status reports from node reports, decide=ing which directive should be "skipped"
    */
   def buildRuleStatusReport(ruleId: RuleId, nodeReports: Map[NodeId, NodeStatusReport]): RuleStatusReport = {
-    val toKeep = nodeReports.values.flatMap( _.report.reports ).filter(_.ruleId == ruleId).toList
+    val toKeep = nodeReports.values.flatMap( _.reports ).filter(_.ruleId == ruleId).toList
     // we don't keep overrides for a directive which is already in "toKeep"
     val toKeepDir = toKeep.map(_.directives.keySet).toSet.flatten
     val overrides = nodeReports.values.flatMap( _.overrides.filterNot(r => toKeepDir.contains(r.policy.directiveId))).toList.distinct
@@ -154,7 +154,7 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
     if(reports.isEmpty) {
       None
     } else { // aggregate values
-      val complianceLevel = ComplianceLevel.sum(reports.flatMap( _._2.report.reports.toSeq.map( _.compliance)))
+      val complianceLevel = ComplianceLevel.sum(reports.flatMap( _._2.reports.toSeq.map( _.compliance)))
       val n2 = System.currentTimeMillis
       TimingDebugLogger.trace(s"Agregating compliance level for  global user compliance in: ${n2-n1}ms")
 
@@ -196,7 +196,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
     //display compliance value and expiration date.
     c.map { case (nodeId, status) =>
 
-      val reportsString = status.report.reports.map { r =>
+      val reportsString = status.reports.map { r =>
         s"${r.ruleId.value}[exp:${r.expirationDate}]${r.compliance.toString}"
       }.mkString("\n  ", "\n  ", "")
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -44,7 +44,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
 
-import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -233,7 +232,7 @@ class StatusReportTest extends Specification {
     """))
 
     "Filter out n2" in {
-      report.report.reports.map( _.nodeId).toSet === Set(NodeId("n1"))
+      report.reports.map( _.nodeId).toSet === Set(NodeId("n1"))
     }
 
     "Correctly compute the compliance" in {
@@ -320,7 +319,7 @@ class StatusReportTest extends Specification {
     }
   }
 
-  private[this] def parse(s: String): Seq[RuleNodeStatusReport] = {
+  private[this] def parse(s: String): Set[RuleNodeStatusReport] = {
 
 
     def ?(s: String): Option[String] = s.trim match {
@@ -345,7 +344,7 @@ class StatusReportTest extends Specification {
         case _ => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
       }
     }.flatten.toList
-  }
+  }.toSet
 
 
   private[this] def toRT(s: String): ReportType = s.toLowerCase match {
@@ -361,7 +360,7 @@ class StatusReportTest extends Specification {
     case s => throw new IllegalArgumentException(s)
   }
 
-  private[this] def aggregate(nr: Seq[RuleNodeStatusReport]): AggregatedStatusReport = {
+  private[this] def aggregate(nr: Iterable[RuleNodeStatusReport]): AggregatedStatusReport = {
     AggregatedStatusReport(nr)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -228,12 +228,7 @@ class StatusReportTest extends Specification {
        n1, r1, 0, d1, c1  , v1  , "", pending   , pending msg
        n1, r2, 0, d1, c0  , v0  , "", success   , pending msg
        n1, r3, 0, d1, c1  , v1  , "", error     , pending msg
-       n2, r4, 0, d1, c0  , v0  , "", pending   , pending msg
-    """))
-
-    "Filter out n2" in {
-      report.reports.map( _.nodeId).toSet === Set(NodeId("n1"))
-    }
+    """).toSet)
 
     "Correctly compute the compliance" in {
       report.compliance === ComplianceLevel(pending = 2, success = 1, error = 1)
@@ -319,7 +314,7 @@ class StatusReportTest extends Specification {
     }
   }
 
-  private[this] def parse(s: String): Set[RuleNodeStatusReport] = {
+  private[this] def parse(s: String): List[RuleNodeStatusReport] = {
 
 
     def ?(s: String): Option[String] = s.trim match {
@@ -344,7 +339,7 @@ class StatusReportTest extends Specification {
         case _ => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
       }
     }.flatten.toList
-  }.toSet
+  }
 
 
   private[this] def toRT(s: String): ReportType = s.toLowerCase match {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -739,7 +739,7 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = (getNodeStatusReportsByRule _).tupled(param)
 
     "have one detailed reports when we create it with one report" in {
-      nodeStatus(one).report.reports.size === 1
+      nodeStatus(one).reports.size === 1
     }
 
     "have one detailed success node when we create it with one success report" in {
@@ -747,11 +747,11 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one detailed rule success directive when we create it with one success report" in {
-      nodeStatus(one).report.reports.head.directives.head._1 === DirectiveId("policy")
+      nodeStatus(one).reports.head.directives.head._1 === DirectiveId("policy")
     }
 
     "have no detailed rule non-success directive when we create it with one success report" in {
-      AggregatedStatusReport(nodeStatus(one).report.reports).compliance === ComplianceLevel(success = 1)
+      AggregatedStatusReport(nodeStatus(one).reports).compliance === ComplianceLevel(success = 1)
     }
   }
 
@@ -778,7 +778,7 @@ class ExecutionBatchTest extends Specification {
 
     "have a pending node when we create it with one wrong success report right now" in {
       (nodeStatus.keySet.head === one) and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet).compliance === ComplianceLevel(missing = 1)
     }
   }
 
@@ -808,7 +808,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one unexpected node when we create it with one success report" in {
       nodeStatus.head._1 === one and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(unexpected = 2)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet).compliance === ComplianceLevel(unexpected = 2)
     }
   }
 
@@ -834,7 +834,7 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one success, and one pending node, in the component detail of the rule" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(success = 1, missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet).compliance === ComplianceLevel(success = 1, missing = 1)
     }
   }
 
@@ -861,7 +861,7 @@ class ExecutionBatchTest extends Specification {
       nodeStatus.size === 3
     }
     "have one detailed rule report with a 67% compliance" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(success = 2, missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet).compliance === ComplianceLevel(success = 2, missing = 1)
     }
   }
 
@@ -893,7 +893,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet)
 
     "have two detailed node rule report" in {
       nodeStatus.size === 3
@@ -935,7 +935,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -980,7 +980,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.reports).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -1025,7 +1025,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
+      nodeStatus.head._2.reports.head.compliance.pc.success === 100
     }
 
   }
@@ -1054,7 +1054,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.pc.success === 100
     }
   }
 
@@ -1080,7 +1080,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.pc.success === 100
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceTest.scala
@@ -109,11 +109,11 @@ class ReportingServiceTest extends Specification {
     val reports = List(
       NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK
         , List()
-        , List(rnReport(node1, rule1, dir1))
+        , Set(rnReport(node1, rule1, dir1))
       )
     , NodeStatusReport(node2, NoRunNoExpectedReport, RunComplianceInfo.OK
         , List(thisOverrideThatOn(rule2, rule1, dir1))
-        , List()
+        , Set()
       )
     ).map(r => (r.nodeId, r)).toMap
 
@@ -129,7 +129,7 @@ class ReportingServiceTest extends Specification {
     val reports = List(
       NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK
         , List(thisOverrideThatOn(rule2, rule1, dir1))
-        , List()
+        , Set()
       )
     ).map(r => (r.nodeId, r)).toMap
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -248,7 +248,7 @@ class ComplianceAPIService(
     } yield {
 
       //flatMap of Set is ok, since nodeRuleStatusReport are different for different nodeIds
-      val reportsByRule = reportsByNode.flatMap { case(nodeId, status) => status.report.reports }.groupBy( _.ruleId)
+      val reportsByRule = reportsByNode.flatMap { case(nodeId, status) => status.reports }.groupBy( _.ruleId)
 
       // get an empty-initialized array of compliances to be used
       // as defaults
@@ -395,9 +395,9 @@ class ComplianceAPIService(
           ByNodeNodeCompliance(
               nodeId
             , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
-            , ComplianceLevel.sum(status.report.reports.map(_.compliance))
+            , ComplianceLevel.sum(status.reports.map(_.compliance))
             , compliance.mode
-            , status.report.reports.toSeq.map(r =>
+            , status.reports.toSeq.map(r =>
                ByNodeRuleCompliance(
                     r.ruleId
                   , ruleMap.get(r.ruleId).map(_.name).getOrElse("Unknown rule")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -122,7 +122,7 @@ class AsyncComplianceService (
         reports <- reportingService.findRuleNodeStatusReports(nodeIds, ruleIds)
       } yield {
         val found = reports.map { case (nodeId, status) =>
-          toCompliance(nodeId, status.report.reports)
+          toCompliance(nodeId, status.reports)
         }
         //add missing elements with "None" compliance, see #7281, #8030, #8141, #11842
         val missingIds = nodeIds -- found.keySet
@@ -146,7 +146,7 @@ class AsyncComplianceService (
         reports <- reportingService.findRuleNodeStatusReports(nodeIds, ruleIds)
       } yield {
         //flatMap on a Set is OK, since reports are different for different nodeIds
-        val found = reports.flatMap( _._2.report.reports ).groupBy( _.ruleId ).map { case (ruleId, reports) =>
+        val found = reports.flatMap( _._2.reports ).groupBy( _.ruleId ).map { case (ruleId, reports) =>
           toCompliance(ruleId, reports)
         }
         // add missing elements with "None" compliance, see #7281, #8030, #8141, #11842

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -332,7 +332,7 @@ class ReportDisplayer(
              * In these case, filter out "unexpected" reports to only
              * keep missing ones, and do not show the "compliance" row.
              */
-            val filtered = NodeStatusReport(report.nodeId, report.runInfo, report.statusInfo, report.overrides, report.report.reports.flatMap { x =>
+            val filtered = NodeStatusReport(report.nodeId, report.runInfo, report.statusInfo, report.overrides, report.reports.flatMap { x =>
               x.withFilteredElements(
                   _ => true   //keep all (non empty) directives
                 , _ => true   //keep all (non empty) component values
@@ -514,7 +514,7 @@ class ReportDisplayer(
     * we could add more information at each level (directive name? rule name?)
     */
     for {
-      (_, directive) <- nodeStatusReports.report.directives
+      (_, directive) <- DirectiveStatusReport.merge(nodeStatusReports.reports.toIterable.flatMap(_.directives.values))
       value          <- directive.getValues(v => v.status == status)
     } yield {
       val (techName, techVersion) = directiveLib.allDirectives.get(value._1).map { case(tech,dir) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -193,7 +193,7 @@ class HomePage extends Loggable {
       // log global compliance info (useful for metrics on number of components and log data analysis)
       ComplianceLogger.info(s"[metrics] global compliance (number of components): ${global.map(g => g._1.total + " "+ g._1.toString).getOrElse("undefined")}")
 
-      val reportsByNode = reports.mapValues { status => ComplianceLevel.sum(status.report.reports.map(_.compliance)) }
+      val reportsByNode = reports.mapValues { status => ComplianceLevel.sum(status.reports.map(_.compliance)) }
 
       /*
        * Here, for the compliance by node, we want to distinguish (but NOT ignore, like in globalCompliance) the


### PR DESCRIPTION
This PR directly use a `Set[RuleNodeStatusReport]` in `NodeStatusReport`. It seems to change nothing, and it allows to avoid a lots of `AggregatedReports` alloc. 