### PR TITLE
Proposal for update in nodeconfigcache

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -49,11 +49,11 @@ import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.RudderPropertiesRepository
 import com.normation.rudder.services.nodes.NodeInfoService
-
 import net.liftweb.actor._
 import net.liftweb.common._
 import com.normation.rudder.domain.logger.ScheduledJobLogger
-import com.normation.box._
+import com.normation.errors._
+import com.normation.zio._
 
 /**
  * This object will be used as message for the non compliant reports logger
@@ -110,11 +110,11 @@ class AutomaticReportLogger(
           // Report logger was not running before, try to log the last hundred reports and initialize lastId
           case Empty =>
             logger.warn("Automatic report logger has never run, logging latest 100 non compliant reports")
-            val isSuccess = for {
-              hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind)
+            val isSuccess = (for {
+              hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind).toIO
               nodes          <- nodeInfoService.getAll()
-              rules          <- ruleRepository.getAll(true).toBox
-              directives     <- directiveRepository.getFullDirectiveLibrary().toBox
+              rules          <- ruleRepository.getAll(true)
+              directives     <- directiveRepository.getFullDirectiveLibrary()
             } yield {
               val id = hundredReports.headOption match {
                 // None means this is a new rudder without any reports, don't log anything, current id is 0
@@ -128,12 +128,12 @@ class AutomaticReportLogger(
                   report._1
               }
               updateLastId(id)
-            }
+            }).either.runNow
 
             isSuccess match {
-              case eb:EmptyBox =>
-                logger.error("report logger could not fetch latest 100 non compliant reports, retry on next run",eb)
-              case Full(x) => //
+              case Left(err) =>
+                logger.error(s"report logger could not fetch latest 100 non compliant reports, retry on next run: ${err.fullMsg}")
+              case Right(x) => //
             }
 
           case Full(lastId) =>
@@ -217,14 +217,14 @@ class AutomaticReportLogger(
       logger.debug(s"Writting non-compliant-report logs beetween ids ${startAt} and ${maxId} (both incuded)")
       (for {
         nodes      <- nodeInfoService.getAll()
-        rules      <- ruleRepository.getAll(true).toBox
-        directives <- directiveRepository.getFullDirectiveLibrary().toBox
+        rules      <- ruleRepository.getAll(true)
+        directives <- directiveRepository.getFullDirectiveLibrary()
       } yield {
         logRec(startAt, maxId, 10000, nodes, rules.map(r => (r.id, r)).toMap, directives)
-      }) match {
-          case eb: EmptyBox =>
-            logger.error("report logger could not fetch latest non compliant reports, try on next run", eb)
-          case Full(id) =>
+      }).either.runNow match {
+          case Left(err) =>
+            logger.error(s"report logger could not fetch latest non compliant reports, try on next run: ${err}")
+          case Right(id) =>
             logger.trace(s"***** done: log report beetween ids ${startAt} and ${maxId}")
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -155,7 +155,7 @@ class FetchDataServiceImpl(nodeInfoService: NodeInfoService, reportingService: R
     (for {
       accepted   <- nodeInfoService.getAll()
       pending    <- nodeInfoService.getPendingNodeInfos()
-      compliance <- reportingService.getUserNodeStatusReports()
+      compliance <- reportingService.getUserNodeStatusReports().toIO
     } yield {
       val modes = compliance.values.groupMapReduce(r => mode(r.compliance))(_ => 1)(_+_)
       FrequentNodeMetrics(
@@ -165,7 +165,7 @@ class FetchDataServiceImpl(nodeInfoService: NodeInfoService, reportingService: R
         , modes.getOrElse(Mode.Enforce, 0)
         , modes.getOrElse(Mode.Mixed, 0)
       )
-    }).toIO
+    })
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
@@ -44,6 +44,7 @@ import org.joda.time.Duration
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.domain.Constants
+import com.normation.box._
 
 /**
  * Class that contains all relevant information about the reporting configuration:
@@ -130,7 +131,7 @@ class AgentRunIntervalServiceImpl (
     for {
       gInterval  <- readGlobalInterval()
       gHeartbeat <- readGlobalHeartbeat()
-      nodeInfos  <- nodeInfoService.getAll()
+      nodeInfos  <- nodeInfoService.getAll().toBox
     } yield {
       nodeIds.map { nodeId =>
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
@@ -46,13 +46,14 @@ import com.normation.rudder.db.Doobie._
 import doobie._
 import doobie.implicits._
 import cats.implicits._
-import com.normation.errors.{BoxToIO, IOResult}
+import com.normation.errors.IOResult
 import com.normation.rudder.domain.logger.TimingDebugLogger
-import com.normation.utils.Control.sequence
 import com.normation.rudder.domain.reports.{ExpectedReportsSerialisation, NodeAndConfigId, NodeConfigId, NodeExpectedReports}
 import com.normation.rudder.services.reports.NodeConfigurationService
 import org.joda.time.DateTime
 import zio.interop.catz._
+import zio._
+import zio.syntax._
 
 final case class RoReportsExecutionRepositoryImpl (
     db              : Doobie
@@ -132,7 +133,7 @@ final case class RoReportsExecutionRepositoryImpl (
    * If none is known for a node, then returned None, so that the property
    * "nodeIds == returnedMap.keySet" holds.
    */
-  override def getNodesLastRun(nodeIds: Set[NodeId]): Box[Map[NodeId, Option[AgentRunWithNodeConfig]]] = {
+  override def getNodesLastRun(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = {
     //deserialization of nodeConfig from the outer join: just report the error + None
     def unserNodeConfig(opt1: Option[String], opt2: Option[String], opt3: Option[DateTime], opt4: Option[DateTime], opt5: Option[String]) = {
       (opt1, opt2, opt3, opt4, opt5) match {
@@ -150,10 +151,10 @@ final case class RoReportsExecutionRepositoryImpl (
     }
 
     val batchedNodeConfigIds = nodeIds.grouped(jdbcMaxBatchSize).toSeq
-    sequence(batchedNodeConfigIds) { ids: Set[NodeId] =>
+    ZIO.foreach(batchedNodeConfigIds) { ids: Set[NodeId] =>
       // map node id to // ('node-id') // to use in values
       ids.map(id => s"('${id.value}')").toList match {
-        case Nil => Full(Map[NodeId, Option[AgentRunWithNodeConfig]]())
+        case Nil => Map[NodeId, Option[AgentRunWithNodeConfig]]().succeed
         case nodes =>
           // we can't use "Fragments.in", because of: https://github.com/tpolecat/doobie/issues/426
           // so we use:
@@ -207,7 +208,7 @@ final case class RoReportsExecutionRepositoryImpl (
 
           }
 
-        transactRunBox(xa => query.transact(xa))
+        transactIOResult(s"Error when trying to fetch node last agent runs information")(xa => query.transact(xa))
       }
     }
   }.map(_.flatten.toMap)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ExpectedReportsRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ExpectedReportsRepository.scala
@@ -110,7 +110,7 @@ trait FindExpectedReportRepository {
    * Return node ids associated to the rule (based on expectedreports (the one still pending)) for this Rule,
    * only limited on the nodeIds in parameter (used when cache is incomplete)
    */
-  def findCurrentNodeIdsForRule(ruleId : RuleId, nodeIds: Set[NodeId]) : Box[Set[NodeId]]
+  def findCurrentNodeIdsForRule(ruleId : RuleId, nodeIds: Set[NodeId]) : IOResult[Set[NodeId]]
 
 
   /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -41,7 +41,6 @@ import com.normation.inventory.domain._
 import org.joda.time.DateTime
 import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.rudder.domain.NodeDit
-import net.liftweb.common._
 import com.normation.rudder.domain.nodes.{Node, NodeInfo}
 import com.normation.rudder.domain.RudderLDAPConstants._
 import com.normation.inventory.ldap.core.LDAPConstants._
@@ -62,7 +61,6 @@ import com.normation.ldap.sdk.LDAPIOResult._
 import zio._
 import zio.syntax._
 import com.normation.errors._
-import com.normation.box._
 import com.normation.zio._
 import com.normation.ldap.sdk.syntax._
 import com.normation.rudder.domain.logger.NodeLoggerPure
@@ -117,17 +115,12 @@ trait NodeInfoService {
    * Retrieve minimal information needed for the node info, used (only) by the
    * LDAP QueryProcessor.
    */
-  def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]]
+  def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]]
 
   /**
    * Return a NodeInfo from a NodeId. First check the ou=Node, then fetch the other data
-   * @param nodeId
-   * @return
    */
-  def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]]
-
-  // Pure version of getNodeInfo
-  def getNodeInfoPure(nodeId: NodeId) : IOResult[Option[NodeInfo]]
+  def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]]
 
   /**
    * Return the number of managed (ie non policy server, no rudder role )nodes.
@@ -144,7 +137,7 @@ trait NodeInfoService {
    * missing (but the corresponding nodeInfos won't be present)
    * So it is possible that getAllIds.size > getAll.size
    */
-  def getAll() : Box[Map[NodeId, NodeInfo]]
+  def getAll() : IOResult[Map[NodeId, NodeInfo]]
 
   /**
    * Get all nodes id
@@ -159,29 +152,22 @@ trait NodeInfoService {
    * missing (but the corresponding nodeInfos won't be present)
    * So it is possible that getAllIds.size > getAll.size
    */
-  def getAllNodes() : Box[Map[NodeId, Node]]
+  def getAllNodes() : IOResult[Map[NodeId, Node]]
 
   /**
    * Get all systen node ids, for example
    * policy server node ids.
    * @return
    */
-  def getAllSystemNodeIds() : Box[Seq[NodeId]]
+  def getAllSystemNodeIds() : IOResult[Seq[NodeId]]
 
   /**
    * Getting something like a nodeinfo for pending / deleted nodes
    */
-  def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]]
-  def getPendingNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = {
-    getPendingNodeInfoPure(nodeId).toBox
-  }
-  def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]]
-
-  def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]]
-  def getDeletedNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = {
-    getDeletedNodeInfoPure(nodeId).toBox
-  }
-  def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]]
+  def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]]
+  def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]]
+  def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]]
+  def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]]
 }
 
 object NodeInfoService {
@@ -815,10 +801,6 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     }
   }
 
-  override final def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = getNotAcceptedNodeDataFromBackend(PendingInventory).toBox
-
-  override final def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = getNotAcceptedNodeDataFromBackend(RemovedInventory).toBox
-
   private[this] def getNotAcceptedNodeInfo(nodeId: NodeId, status: InventoryStatus): IOResult[Option[NodeInfo]] = {
     val dit = status match {
       case AcceptedInventory => inventoryDit
@@ -849,8 +831,10 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     }
   }
 
-  override final def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getNotAcceptedNodeInfo(nodeId, PendingInventory)
-  override final def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getNotAcceptedNodeInfo(nodeId, RemovedInventory)
+  override final def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getNotAcceptedNodeDataFromBackend(PendingInventory)
+  override final def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getNotAcceptedNodeDataFromBackend(RemovedInventory)
+  override final def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getNotAcceptedNodeInfo(nodeId, PendingInventory)
+  override final def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getNotAcceptedNodeInfo(nodeId, RemovedInventory)
 
   /**
    * Clear cache.
@@ -866,21 +850,21 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     semaphore.withPermit(UIO.effectTotal(this.nodeCache.map(_.lastModTime).getOrElse(new DateTime(0))))
   }
 
-  def getAll(): Box[Map[NodeId, NodeInfo]] = withUpToDateCache("all nodes info") { cache =>
+  def getAll(): IOResult[Map[NodeId, NodeInfo]] = withUpToDateCache("all nodes info") { cache =>
     cache.view.mapValues(_._2).toMap.succeed
-  }.toBox
+  }
   def getAllNodesIds(): IOResult[Set[NodeId]] = withUpToDateCache("all nodes id") { cache =>
     cache.keySet.succeed
   }
-  def getAllSystemNodeIds(): Box[Seq[NodeId]] = withUpToDateCache("all system nodes") { cache =>
+  def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = withUpToDateCache("all system nodes") { cache =>
     cache.collect { case(k, (_,x)) if(x.isPolicyServer) => k }.toSeq.succeed
-  }.toBox
+  }
 
-  def getAllNodes(): Box[Map[NodeId, Node]] = withUpToDateCache("all nodes") { cache =>
+  def getAllNodes(): IOResult[Map[NodeId, Node]] = withUpToDateCache("all nodes") { cache =>
     cache.view.mapValues(_._2.node).toMap.succeed
-  }.toBox
+  }
 
-  override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): Box[Set[LDAPNodeInfo]] = {
+  override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = {
     // if nodeIds is empty and composition is and, return an empty set; with or, we need to run it in all cases
     if (nodeIds.isEmpty && composition == And) {
       Set[LDAPNodeInfo]().succeed
@@ -889,11 +873,9 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
         PostFilterNodeFromInfoService.getLDAPNodeInfo(nodeIds, predicates, composition, cache).succeed
       }
     }
-  }.toBox
+  }
 
-  def getNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = getNodeInfoPure(nodeId).toBox
-
-  def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = withUpToDateCache(s"${nodeId.value} node info") { cache =>
+  def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = withUpToDateCache(s"${nodeId.value} node info") { cache =>
     cache.get(nodeId).map( _._2).succeed
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -740,7 +740,7 @@ trait PromiseGeneration_performeIO extends PromiseGenerationService {
   def getGlobalPolicyMode: () => Box[GlobalPolicyMode]
 
   override def findDependantRules() : Box[Seq[Rule]] = roRuleRepo.getAll(true).toBox
-  override def getAllNodeInfos(): Box[Map[NodeId, NodeInfo]] = nodeInfoService.getAll()
+  override def getAllNodeInfos(): Box[Map[NodeId, NodeInfo]] = nodeInfoService.getAll().toBox
   override def getDirectiveLibrary(): Box[FullActiveTechniqueCategory] = roDirectiveRepository.getFullDirectiveLibrary().toBox
   override def getGroupLibrary(): Box[FullNodeGroupCategory] = roNodeGroupRepository.getFullGroupLibrary().toBox
   override def getAllGlobalParameters: Box[Seq[GlobalParameter]] = parameterService.getAllGlobalParameters()

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -177,7 +177,7 @@ class AcceptedNodesLDAPQueryProcessor(
       res            <- processor.internalQueryProcessor(query,select,limitToNodeIds,debugId).toBox
       timeres        =  (System.currentTimeMillis - timePreCompute)
       _              =  logger.debug(s"LDAP result: ${res.entries.size} entries obtained in ${timeres}ms for query ${query.toString}")
-      ldapEntries    <- nodeInfoService.getLDAPNodeInfo(res.entries.flatMap(x => x(A_NODE_UUID).map(NodeId(_))).toSet, res.nodeFilters, query.composition)
+      ldapEntries    <- nodeInfoService.getLDAPNodeInfo(res.entries.flatMap(x => x(A_NODE_UUID).map(NodeId(_))).toSet, res.nodeFilters, query.composition).toBox
       ldapEntryTime  =  (System.currentTimeMillis - timePreCompute - timeres)
       _              =  logger.debug(s"[post-filter:rudderNode] Found ${ldapEntries.size} nodes when filtering for info service existence and properties (${ldapEntryTime} ms)")
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -65,7 +65,6 @@ import scala.util.control.NonFatal
 import net.liftweb.common.Loggable
 
 import com.normation.box._
-import com.normation.errors._
 
 /**
  * Correctly quote a token
@@ -226,7 +225,7 @@ object QSLdapBackend {
 
     for {
       connection  <- ldap
-      nodeIds     <- nodeInfos.getAllNodesIds
+      nodeIds     <- nodeInfos.getAllNodesIds()
       entries     <- connection.search(nodeDit.BASE_DN, Sub, filter, returnedAttributes:_*)
     } yield {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.reports
 
+import com.normation.errors.IOResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.policies.RuleId
@@ -62,7 +63,7 @@ trait ReportingService {
   /**
    * A specialised version of `findRuleNodeStatusReports` to find node status reports for a given rule.
    */
-  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]]
+  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]]
 
   /**
     * find node status reports for a given node.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -84,7 +84,8 @@ import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.queries.QueryProcessor
-import com.normation.rudder.services.reports.CacheComplianceQueueAction.InsertNodeInCache
+import com.normation.rudder.services.reports.CacheComplianceQueueAction.ExpectedReportAction
+import com.normation.rudder.services.reports.CacheExpectedReportAction.InsertNodeInCache
 import com.normation.rudder.services.reports.{CachedFindRuleNodeStatusReports, CachedNodeConfigurationService}
 import com.normation.utils.Control.sequence
 import net.liftweb.common.Box
@@ -594,10 +595,9 @@ trait ComposedNewNodeManager extends NewNodeManager with NewNodeManagerHooks {
          afterNodeAcceptedAsync(id)
          // ping the NodeConfiguration Cache and NodeCompliance Cache about this new node
 
-         val addEvent = Seq((id, InsertNodeInCache(id)))
          for {
-           _ <- cachedNodeConfigurationService.invalidateWithAction(addEvent).toBox ?~! s"Error when adding node ${id.value} to node configuration cache"
-           _ <- cachedReportingService.invalidateWithAction(addEvent).toBox ?~! s"Error when adding node ${id.value} to compliance cache"
+           _ <- cachedNodeConfigurationService.invalidateWithAction(Seq((id, InsertNodeInCache(id)))).toBox ?~! s"Error when adding node ${id.value} to node configuration cache"
+           _ <- cachedReportingService.invalidateWithAction(Seq((id, ExpectedReportAction(InsertNodeInCache(id))))).toBox ?~! s"Error when adding node ${id.value} to compliance cache"
          } yield {
            ()
          }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -168,7 +168,7 @@ class PostNodeAcceptanceHookScripts(
     val postHooksTime =  System.currentTimeMillis
     HooksLogger.debug(s"Executing post-node-acceptance hooks for node with id '${nodeId.value}'")
     for {
-      optNodeInfo   <- nodeInfoService.getNodeInfo(nodeId)
+      optNodeInfo   <- nodeInfoService.getNodeInfo(nodeId).toBox
       nodeInfo      <- optNodeInfo match {
                          case None    => Failure(s"Just accepted node with id '${nodeId.value}' was not found - perhaps a bug?"+
                                                   " Please report with /var/log/rudder/webapp/DATE_OF_DAY.stdout.log file attached")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -248,14 +248,14 @@ class RemoveNodeServiceImpl(
           // always delete in order pending then accepted then deleted
            res1  <- if(status.contains(PendingInventory)) {
                       (for {
-                        i <- nodeInfoService.getPendingNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getPendingNodeInfo(nodeId)
                         r <- deletePendingNode(nodeId, mode, modId, actor)
                         _ <- info.set(i)
                       } yield r).catchAll(err => Error(err).succeed)
                     } else Success.succeed
            res2  <- if(status.contains(AcceptedInventory)) {
                       (for {
-                        i <- nodeInfoService.getNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getNodeInfo(nodeId)
                         r <- i match {
                                case None    => Success.succeed // perhaps deleted or something
                                case Some(x) => info.set(Some(x)) *> deleteAcceptedNode(x, mode, modId, actor)
@@ -264,7 +264,7 @@ class RemoveNodeServiceImpl(
                     } else Success.succeed
            res3  <- if(status.contains(RemovedInventory)) {
                       (for {
-                        i <- nodeInfoService.getDeletedNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getDeletedNodeInfo(nodeId)
                         r <- deleteDeletedNode(nodeId, mode, modId, actor)
                         // only update if nodeInfo is not already set, b/c accepted has more info
                         _ <- info.update(opt => opt.orElse(i))
@@ -402,7 +402,7 @@ class RemoveNodeServiceImpl(
           Map((node.id, node)).succeed
         } else {
           for {
-            opt    <- nodeInfoService.getNodeInfoPure(node.policyServerId)
+            opt    <- nodeInfoService.getNodeInfo(node.policyServerId)
             parent <- opt.notOptional(s"The policy server '${node.policyServerId.value}' for node ${node.hostname} ('${node.id.value}') was not found in Rudder")
             rec    <- recGetParent(parent)
           } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -94,30 +94,29 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]] = ???
-    def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]] = ???
-    def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]] = ???
+    def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
-    def getAllNodes() : Box[Map[NodeId, Node]] = ???
+    def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
-    def getAllSystemNodeIds() : Box[Seq[NodeId]] = ???
-    def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
-    def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
+    def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNumberOfManagedNodes: Int = ???
-    val getAll : Box[Map[NodeId, NodeInfo]] = {
+    val getAll : IOResult[Map[NodeId, NodeInfo]] = {
       def build(id: String, mode: Option[PolicyMode]) = {
         val node1 = NodeConfigData.node1.node
         NodeConfigData.node1.copy(node = node1.copy(id = NodeId(id), policyMode = mode))
       }
-      Full(Seq(
+      Seq(
           build("n0", None)
         , build("n1", Some(PolicyMode.Enforce))
         , build("n2", Some(PolicyMode.Audit))
         , build("n3", Some(PolicyMode.Enforce))
         , build("n4", Some(PolicyMode.Audit))
-      ).map(n => (n.id, n)).toMap)
+      ).map(n => (n.id, n)).toMap.succeed
     }
   }
 
@@ -153,7 +152,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def defaultFindRuleNodeStatusReports: DefaultFindRuleNodeStatusReports = null
     def nodeInfoService: NodeInfoService = self.nodeInfoService
     def nodeConfigrationService : NodeConfigurationService = null
-    def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = null
+    def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = null
     def findNodeStatusReport(nodeId: NodeId) : Box[NodeStatusReport] = null
     def findUserNodeStatusReport(nodeId: NodeId) : Box[NodeStatusReport] = null
     def findSystemNodeStatusReport(nodeId: NodeId) : Box[NodeStatusReport] = null

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
@@ -1,5 +1,6 @@
 package com.normation.rudder.services.nodes
 
+import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.AcceptedInventory
@@ -45,7 +46,6 @@ import com.normation.rudder.services.servers.UnitAcceptInventory
 import com.normation.rudder.services.servers.UnitRefuseInventory
 import com.unboundid.ldap.sdk.Filter
 import com.unboundid.ldap.sdk.{DN, RDN}
-import net.liftweb.common.Box
 import net.liftweb.common.Full
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
@@ -57,6 +57,7 @@ import scala.collection.mutable.{Map => MutMap}
 import scala.collection.mutable.Buffer
 import scala.concurrent.duration.FiniteDuration
 import com.softwaremill.quicklens._
+import net.liftweb.common.Box
 
 /*
  * Test the cache behaviour
@@ -313,10 +314,16 @@ class NodeInfoServiceCachedTest extends Specification {
       }
     }
 
-    implicit class ForceGet[A](b: Box[A]) {
+    implicit class ForceGetBox[A](b: Box[A]) {
       def forceGet = b match {
         case Full(a) => a
         case eb      => throw new IllegalArgumentException(s"Error during test, box is an erro: ${eb}")
+      }
+    }
+    implicit class ForceGetIO[A](b: IOResult[A]) {
+      def forceGet = b.either.runNow match {
+        case Right(a)  => a
+        case Left(err) => throw new IllegalArgumentException(s"Error during test, box is an erro: ${err.fullMsg}")
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -62,6 +62,7 @@ import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
+import zio.syntax._
 
 /*
  * Test the cache behaviour
@@ -131,20 +132,19 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]] = ???
-    def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]] = ???
-    def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]] = ???
+    def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
-    def getAllNodes() : Box[Map[NodeId, Node]] = ???
+    def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
-    def getAllSystemNodeIds() : Box[Seq[NodeId]] = ???
-    def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
-    def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
+    def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNumberOfManagedNodes: Int = ???
-    val getAll : Box[Map[NodeId, NodeInfo]] = {
-      Full(nodes.map { case (n, _, _) => (n.id, n) }.toMap)
+    val getAll : IOResult[Map[NodeId, NodeInfo]] = {
+      nodes.map { case (n, _, _) => (n.id, n) }.toMap.succeed
     }
   }
 
@@ -161,7 +161,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       override def agentRunRepository: RoReportsExecutionRepository = ???
       override def getGlobalComplianceMode: () => Box[GlobalComplianceMode] = ???
       override def getUnexpectedInterpretation: () => Box[UnexpectedReportInterpretation] = ???
-      override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = ???
+      override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = ???
       override def getUserNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = ???
       override def getUserAndSystemNodeStatusReports(optNodeIds: Option[Set[NodeId]]): Box[(Map[NodeId, NodeStatusReport], Map[NodeId, NodeStatusReport])] = ???
       override def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = ???
@@ -178,7 +178,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     }
     override def nodeInfoService: NodeInfoService = testNodeInfoService
 
-    override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = ???
+    override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = ???
     override def findNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport] = ???
     override def findUncomputedNodeStatusReports() : Box[Map[NodeId, NodeStatusReport]] = ???
     override def getUserNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -122,9 +122,9 @@ import net.liftweb.json.JsonAST.JField
 import net.liftweb.json.JsonAST.JInt
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.JsonAST.JString
-import zio.ZIO
 import zio.duration._
-
+import zio._
+import zio.syntax._
 
 // how to render parent properties in the returned json
 sealed trait RenderInheritedProperties
@@ -260,7 +260,7 @@ class NodeApi (
                       restExtractor.extractNode(req.params)
                     }
         reason   <- restExtractor.extractReason(req)
-        result   <- apiV8service.updateRestNode(NodeId(id), restNode, authzToken.actor, reason)
+        result   <- apiV8service.updateRestNode(NodeId(id), restNode, authzToken.actor, reason).toBox
       } yield {
         toJsonResponse(Some(id), serializer.serializeNode(result))
       }) match {
@@ -380,7 +380,7 @@ class NodeApi (
       implicit val prettify = params.prettify
       (for {
         classes <- restExtractorService.extractList("classes")(req)(json => Full(json))
-        optNode <- apiV2.nodeInfoService.getNodeInfo(NodeId(id))
+        optNode <- apiV2.nodeInfoService.getNodeInfo(NodeId(id)).toBox
       } yield {
         optNode match {
           case Some(node) if(node.agentsName.exists(a => a.agentType == AgentType.CfeCommunity || a.agentType == AgentType.CfeEnterprise)) =>
@@ -413,8 +413,8 @@ class NodeApi (
       (for {
         ids      <- (restExtractorService.extractString("ids")(req)(ids => Full(ids.split(",").map(_.trim)))).map(_.map(_.toList).getOrElse(Nil)) ?~! "Error: 'ids' parameter not found"
         accepted <- apiV2.nodeInfoService.getAllNodesIds().map(_.map(_.value)).toBox ?~! errorMsg(ids)
-        pending  <- apiV2.nodeInfoService.getPendingNodeInfos().map(_.keySet.map(_.value)) ?~! errorMsg(ids)
-        deleted  <- apiV2.nodeInfoService.getDeletedNodeInfos().map(_.keySet.map(_.value)) ?~! errorMsg(ids)
+        pending  <- apiV2.nodeInfoService.getPendingNodeInfos().map(_.keySet.map(_.value)).toBox ?~! errorMsg(ids)
+        deleted  <- apiV2.nodeInfoService.getDeletedNodeInfos().map(_.keySet.map(_.value)).toBox ?~! errorMsg(ids)
       } yield {
         val array = ids.map { id =>
           val status = {
@@ -497,7 +497,7 @@ class NodeApiInheritedProperties(
    */
   def getNodePropertiesTree(nodeId: NodeId, renderInHtml: RenderInheritedProperties): IOResult[JValue] = {
     for {
-      nodeInfo     <- infoService.getNodeInfoPure(nodeId).notOptional(s"Node with ID '${nodeId.value}' was not found.'")
+      nodeInfo     <- infoService.getNodeInfo(nodeId).notOptional(s"Node with ID '${nodeId.value}' was not found.'")
       groups       <- groupRepo.getFullGroupLibrary()
       nodeTargets  =  groups.getTarget(nodeInfo).map(_._2).toList
       params       <- paramRepo.getAllGlobalParameters()
@@ -662,15 +662,15 @@ class NodeApiService13 (
       optNodeIds      <- req.json.flatMap(j => OptionnalJson.extractJsonListString(j, "nodeIds",( values => Full(values.map(NodeId(_))))))
       nodes           <- optNodeIds match {
                            case None =>
-                             nodeInfoService.getAll()
+                             nodeInfoService.getAll().toBox
                            case Some(nodeIds) =>
                              com.normation.utils.Control.sequence(nodeIds)(
-                               nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n)))
+                               nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n))).toBox
                              ).map(_.flatten.toMap)
                          }
       n2              =  System.currentTimeMillis
       _               =  TimingDebugLoggerPure.logEffect.trace(s"Getting node infos: ${n2 - n1}ms")
-      runs            <- reportsExecutionRepository.getNodesLastRun(nodes.keySet)
+      runs            <- reportsExecutionRepository.getNodesLastRun(nodes.keySet).toBox
       n3              =  System.currentTimeMillis
       _               =  TimingDebugLoggerPure.logEffect.trace(s"Getting run infos: ${n3 - n2}ms")
       (systemCompliances, userCompliances) <- reportingService.getUserAndSystemNodeStatusReports(Some(nodes.keySet))
@@ -720,8 +720,8 @@ class NodeApiService13 (
       optNodeIds <- req.json.flatMap(restExtractor.extractNodeIdsFromJson)
 
       nodes <- optNodeIds match {
-        case None => nodeInfoService.getAll()
-        case Some(nodeIds) => com.normation.utils.Control.sequence(nodeIds)(nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n)))).map(_.flatten.toMap)
+        case None => nodeInfoService.getAll().toBox
+        case Some(nodeIds) => ZIO.foreach(nodeIds)(nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n)))).toBox.map(_.flatten.toMap)
       }
       softs <- readOnlySoftwareDAO.getNodesbySofwareName(software).toBox.map(_.toMap)
     } yield {
@@ -733,10 +733,10 @@ class NodeApiService13 (
   def property(req : Req, property : String, inheritedValue : Boolean) = {
     for {
       optNodeIds <- req.json.flatMap(restExtractor.extractNodeIdsFromJson)
-      nodes      <- optNodeIds match {
+      nodes      <- (optNodeIds match {
                       case None => nodeInfoService.getAll()
-                      case Some(nodeIds) => com.normation.utils.Control.sequence(nodeIds)(nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n)))).map(_.flatten.toMap)
-                    }
+                      case Some(nodeIds) => ZIO.foreach(nodeIds)(nodeInfoService.getNodeInfo(_).map(_.map(n => (n.id, n)))).map(_.flatten.toMap)
+                    }).toBox
       propMap = nodes.values.groupMapReduce(_.id)(n =>  n.properties.filter(_.name == property))(_ ::: _)
 
 
@@ -773,7 +773,7 @@ class NodeApiService2 (
   def listAcceptedNodes (req : Req) = {
     implicit val prettify = restExtractor.extractPrettify(req.params)
     implicit val action = "listAcceptedNodes"
-      nodeInfoService.getAll() match {
+      nodeInfoService.getAll().toBox match {
         case Full(nodes) =>
           val acceptedNodes = nodes.values.map(serializeNodeInfo(_,"accepted"))
           toJsonResponse(None, ( "nodes" -> JArray(acceptedNodes.toList)))
@@ -786,7 +786,7 @@ class NodeApiService2 (
   def acceptedNodeDetails (req : Req, id :NodeId ) = {
     implicit val prettify = restExtractor.extractPrettify(req.params)
     implicit val action = "acceptedNodeDetails"
-    nodeInfoService.getNodeInfo(id) match {
+    nodeInfoService.getNodeInfo(id).toBox match {
       case Full(Some(info)) =>
         val node =  serializeNodeInfo(info,"accepted")
         toJsonResponse(None, ( "nodes" -> JArray(List(node))))
@@ -836,7 +836,7 @@ class NodeApiService2 (
   def modifyStatusFromAction(ids : Seq[NodeId], action : NodeStatusAction,modId : ModificationId, actor:EventActor) : Box[List[JValue]] = {
     def actualNodeDeletion(id : NodeId, modId : ModificationId, actor:EventActor) = {
       for {
-        optInfo <- nodeInfoService.getNodeInfo(id)
+        optInfo <- nodeInfoService.getNodeInfo(id).toBox
         info    <- optInfo match {
                      case None    => Failure(s"Can not removed the node with id '${id.value}' because it was not found")
                      case Some(x) => Full(x)
@@ -905,7 +905,7 @@ class NodeApiService4 (
 
   import restSerializer._
 
-  def getNodeDetails(nodeId: NodeId, detailLevel: NodeDetailLevel, state: InventoryStatus, version : ApiVersion): Box[Option[JValue]] = {
+  def getNodeDetails(nodeId: NodeId, detailLevel: NodeDetailLevel, state: InventoryStatus, version : ApiVersion): IOResult[Option[JValue]] = {
     for {
       optNodeInfo <- state match {
                     case AcceptedInventory => nodeInfoService.getNodeInfo(nodeId)
@@ -913,26 +913,26 @@ class NodeApiService4 (
                     case RemovedInventory  => nodeInfoService.getDeletedNodeInfo(nodeId)
                   }
       nodeInfo    <- optNodeInfo match {
-                       case None    => Full(None)
+                       case None    => None.succeed
                        case Some(x) =>
                          for {
                            runs      <- roAgentRunsRepository.getNodesLastRun(Set(nodeId))
                            inventory <- if(detailLevel.needFullInventory()) {
-                                          inventoryRepository.get(nodeId, state).toBox
+                                          inventoryRepository.get(nodeId, state)
                                         } else {
-                                          Full(None)
+                                          None.succeed
                                         }
                            software  <- if(detailLevel.needSoftware()) {
-                                          (for {
+                                          for {
                                             software <- inventory match {
                                                            case Some(i) => softwareRepository.getSoftware(i.node.softwareIds)
                                                            case None    => softwareRepository.getSoftwareByNode(Set(nodeId), state).map( _.get(nodeId).getOrElse(Seq()))
                                                          }
                                           } yield {
                                             software
-                                          }).toBox
+                                          }
                                         } else {
-                                          Full(Seq())
+                                          Seq().succeed
                                         }
                          } yield {
                            Some((x, runs, inventory, software))
@@ -948,13 +948,13 @@ class NodeApiService4 (
   def nodeDetailsWithStatus(nodeId: NodeId, detailLevel: NodeDetailLevel, state: InventoryStatus, version : ApiVersion, req: Req) = {
     implicit val prettify = restExtractor.extractPrettify(req.params)
     implicit val action = s"${state.name}NodeDetails"
-    getNodeDetails(nodeId, detailLevel, state, version) match {
-        case Full(Some(inventory)) =>
+    getNodeDetails(nodeId, detailLevel, state, version).either.runNow match {
+        case Right(Some(inventory)) =>
           toJsonResponse(Some(nodeId.value), ( "nodes" -> JArray(List(inventory))))
-        case Full(None) =>
+        case Right(None) =>
           effectiveResponse (Some(nodeId.value), s"Could not find Node ${nodeId.value} in state '${state.name}'", NotFoundError, action, prettify)
-        case eb: EmptyBox =>
-          val message = (eb ?~ (s"Error when trying to find Node ${nodeId.value} in state '${state.name}'")).msg
+        case Left(err) =>
+          val message = s"Error when trying to find Node ${nodeId.value} in state '${state.name}': ${err.fullMsg}"
           toJsonError(Some(nodeId.value), message)
       }
   }
@@ -965,11 +965,11 @@ class NodeApiService4 (
     (for {
       accepted  <- getNodeDetails(nodeId, detailLevel, AcceptedInventory, version)
       orPending <- accepted match {
-                     case Some(i) => Full(Some(i))
+                     case Some(i) => Some(i).succeed
                      case None    => getNodeDetails(nodeId, detailLevel, PendingInventory, version)
                    }
       orDeleted <- orPending match {
-                     case Some(i) => Full(Some(i))
+                     case Some(i) => Some(i).succeed
                      case None    => getNodeDetails(nodeId, detailLevel, RemovedInventory, version)
                    }
     } yield {
@@ -979,10 +979,10 @@ class NodeApiService4 (
          case None =>
            effectiveResponse (Some(nodeId.value), s"Node with ID '${nodeId.value}' was not found in Rudder", NotFoundError, action, prettify)
        }
-    }) match {
-      case Full(res)   => res
-      case eb:EmptyBox =>
-        val msg = (eb ?~! s"An error was encountered when looking for node with ID '${nodeId.value}'").messageChain
+    }).either.runNow match {
+      case Right(res)   => res
+      case Left(err) =>
+        val msg = s"An error was encountered when looking for node with ID '${nodeId.value}': ${err.fullMsg}"
         toJsonError(Some(nodeId.value), msg)
     }
   }
@@ -1011,14 +1011,14 @@ class NodeApiService6 (
       nodeIds     =  nodeFilter.getOrElse(nodeInfos.keySet).toSet
       runs        <- roAgentRunsRepository.getNodesLastRun(nodeIds)
       inventories <- if(detailLevel.needFullInventory()) {
-                       inventoryRepository.getAllInventories(state).toBox ?~! "Error when looking for node inventories"
+                       inventoryRepository.getAllInventories(state).chainError("Error when looking for node inventories")
                      } else {
-                       Full(Map[NodeId, FullInventory]())
+                       Map[NodeId, FullInventory]().succeed
                      }
       software    <- if(detailLevel.needSoftware()) {
-                       softwareRepository.getSoftwareByNode(nodeInfos.keySet, state).toBox
+                       softwareRepository.getSoftwareByNode(nodeInfos.keySet, state)
                      } else {
-                       Full(Map[NodeId, Seq[Software]]())
+                       Map[NodeId, Seq[Software]]().succeed
                      }
     } yield {
       for {
@@ -1029,12 +1029,12 @@ class NodeApiService6 (
         serializeInventory(nodeInfo, state, runDate, inventories.get(nodeId), software.getOrElse(nodeId, Seq()), detailLevel, version)
       }
     }
-    ) match {
-      case Full(nodes) => {
+    ).either.runNow match {
+      case Right(nodes) => {
         toJsonResponse(None, ( "nodes" -> JArray(nodes.toList)))
       }
-      case eb: EmptyBox => {
-        val message = (eb ?~ (s"Could not fetch ${state.name} Nodes")).messageChain
+      case Left(err) => {
+        val message = s"Could not fetch ${state.name} Nodes: ${err.fullMsg}"
         toJsonError(None, message)
       }
     }
@@ -1069,7 +1069,7 @@ class NodeApiService8 (
   , userService     : UserService
 ) extends Loggable {
 
-  def updateRestNode(nodeId: NodeId, restNode: RestNode, actor : EventActor, reason : Option[String]) : Box[Node] = {
+  def updateRestNode(nodeId: NodeId, restNode: RestNode, actor : EventActor, reason : Option[String]) : IOResult[Node] = {
 
     val modId = ModificationId(uuidGen.newUuid)
 
@@ -1097,16 +1097,16 @@ class NodeApiService8 (
     }
 
     for {
-      node           <- nodeInfoService.getNodeInfo(nodeId).flatMap( _.map( _.node ))
-      newProperties  <- CompareProperties.updateProperties(node.properties, restNode.properties).toBox
+      node           <- nodeInfoService.getNodeInfo(nodeId).map( _.map( _.node )).notOptional(s"node with id '${nodeId.value}' was not found")
+      newProperties  <- CompareProperties.updateProperties(node.properties, restNode.properties).toIO
       updated        =  updateNode(node, restNode, newProperties)
       keyInfo        =  getKeyInfo(restNode)
-      saved          <- if(updated == node) Full(node)
-                        else nodeRepository.updateNode(updated, modId, actor, reason).toBox
+      saved          <- if(updated == node) node.succeed
+                        else nodeRepository.updateNode(updated, modId, actor, reason)
       keyChanged     =  keyInfo._1.isDefined || keyInfo._2.isDefined
       keys           <- if(keyChanged) {
-                           nodeRepository.updateNodeKeyInfo(node.id, keyInfo._1, keyInfo._2, modId, actor, reason).toBox
-                        } else Full(())
+                           nodeRepository.updateNodeKeyInfo(node.id, keyInfo._1, keyInfo._2, modId, actor, reason)
+                        } else UIO.unit
     } yield {
       if(node != updated || keyChanged) {
         asyncRegenerate ! AutomaticStartDeployment(ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor)
@@ -1224,7 +1224,7 @@ class NodeApiService8 (
   def runAllNodes(classes : List[String]) : Box[JValue] = {
 
     for {
-      nodes <- nodeInfoService.getAll() ?~! s"Could not find nodes informations"
+      nodes <- nodeInfoService.getAll().toBox ?~! s"Could not find nodes informations"
 
     } yield {
       val res = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import net.liftweb.http.S
-import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import com.normation.rudder.domain.policies.RuleTarget
 import net.liftweb.http.js.JsCmds.RedirectTo
@@ -162,8 +161,8 @@ class LinkUtil (
   }
 
   def createNodeLink(id: NodeId) = {
-    nodeInfoService.getNodeInfo(id) match {
-      case Full(Some(node)) =>
+    nodeInfoService.getNodeInfo(id).either.runNow match {
+      case Right(Some(node)) =>
         <span>Node <a href={baseNodeLink(id)}>{node.hostname}</a> (Rudder ID: {id.value})</span>
       case _ =>
         <span>Node {id.value}</span>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1398,22 +1398,21 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     def _info(node: NodeDetails) = Option(node.info)
     def _fullInventory(node: NodeDetails) = Option(FullInventory(node.nInv, node.mInv))
 
-    override def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, AcceptedInventory, _info)
-    override def getNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = getNodeInfoPure(nodeId).toBox
+    override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, AcceptedInventory, _info)
 
-    override def getAll(): Box[Map[NodeId, NodeInfo]] = getGenericAll(AcceptedInventory, _info).toBox
+    override def getAll(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(AcceptedInventory, _info)
 
-    override def getAllNodes(): Box[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
-    override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet).toIO
-    override def getAllSystemNodeIds(): Box[Seq[NodeId]] = {
-      nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq ).toBox
+    override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
+    override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
+    override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = {
+      nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq )
     }
 
-    override def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, PendingInventory, _info)
-    override def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = getGenericAll(PendingInventory, _info).toBox
+    override def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, PendingInventory, _info)
+    override def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(PendingInventory, _info)
 
-    override def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, RemovedInventory, _info)
-    override def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = getGenericAll(RemovedInventory, _info).toBox
+    override def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, RemovedInventory, _info)
+    override def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(RemovedInventory, _info)
 
     override def get(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Option[FullInventory]] = getGenericOne(id, inventoryStatus, _fullInventory)
     override def get(id: NodeId): IOResult[Option[FullInventory]] = {
@@ -1428,7 +1427,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): Box[Set[LDAPNodeInfo]] = ???
+    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -109,7 +109,6 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.services.queries.DefaultStringQueryParser
 import com.normation.rudder.services.queries.DynGroupUpdaterServiceImpl
 import com.normation.rudder.services.queries.JsonQueryLexer
-import com.normation.rudder.services.reports.CacheComplianceQueueAction
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.services.system.DebugInfoScriptResult
 import com.normation.rudder.services.system.DebugInfoService
@@ -152,6 +151,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.xml.Elem
 import com.normation.box._
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.services.reports.CacheExpectedReportAction
 
 
 /*
@@ -273,7 +273,7 @@ object RestTestSetUp {
     override def runPreHooks(generationTime: DateTime, systemEnv: HookEnvPairs): Box[Unit] = ???
     override def runPostHooks(generationTime: DateTime, endTime: DateTime, idToConfiguration: Map[NodeId, NodeInfo], systemEnv: HookEnvPairs, nodeIdsPath: String): Box[Unit] = ???
     override def runFailureHooks(generationTime: DateTime, endTime: DateTime, systemEnv: HookEnvPairs, errorMessage: String, errorMessagePath: String): Box[Unit] = ???
-    override def invalidateComplianceCache(actions: Seq[(NodeId, CacheComplianceQueueAction)]): Unit = ???
+    override def invalidateComplianceCache(actions: Seq[(NodeId, CacheExpectedReportAction)]): Unit = ???
   }
   val asyncDeploymentAgent = new AsyncDeploymentActor(policyGeneration, eventLogger, deploymentStatusSerialisation, () => Duration("0s").succeed, () => AllGeneration.succeed)
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -533,7 +533,7 @@ object RestTestSetUp {
   val nodeInfo = mockNodes.nodeInfoService
   val softDao = mockNodes.softwareDao
   val roReportsExecutionRepository = new RoReportsExecutionRepository {
-    override def getNodesLastRun(nodeIds: Set[NodeId]): Box[Map[NodeId, Option[AgentRunWithNodeConfig]]] = Full(Map())
+    override def getNodesLastRun(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = Map.empty[NodeId, Option[AgentRunWithNodeConfig]].succeed
 
     def getNodesAndUncomputedCompliance(): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = ???
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/LoadNodeComplianceCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/LoadNodeComplianceCache.scala
@@ -42,9 +42,10 @@ import bootstrap.liftweb.BootstrapLogger
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.reports.CachedFindRuleNodeStatusReports
 import javax.servlet.UnavailableException
-import com.normation.box._
-import com.normation.rudder.services.reports.CacheComplianceQueueAction.InsertNodeInCache
+import com.normation.rudder.services.reports.CacheExpectedReportAction.InsertNodeInCache
+import com.normation.rudder.services.reports.CacheComplianceQueueAction.ExpectedReportAction
 import net.liftweb.common.EmptyBox
+import com.normation.box._
 
 /**
  * At startup, we preload node compliance cache
@@ -57,7 +58,7 @@ class LoadNodeComplianceCache(nodeInfoService: NodeInfoService, reportingService
   override def checks() : Unit = {
     (for {
       nodeIds <- nodeInfoService.getAllNodesIds()
-      _       <- reportingService.invalidateWithAction(nodeIds.toSeq.map(x => (x, InsertNodeInCache(x))))
+      _       <- reportingService.invalidateWithAction(nodeIds.toSeq.map(x => (x, ExpectedReportAction(InsertNodeInCache(x)))))
     } yield ()).toBox match {
       case eb: EmptyBox =>
         val err = eb ?~! s"Error when loading node compliance cache:"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -65,6 +65,7 @@ import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.web.ChooseTemplate
 import net.liftweb.util.CssSel
 import com.normation.zio._
+import com.normation.box._
 
 object NodeGroupForm {
   val templatePath = "templates-hidden" :: "components" :: "NodeGroupForm" :: Nil
@@ -127,7 +128,7 @@ class NodeGroupForm(
   private[this] def getNodeList(target: Either[NonGroupRuleTarget, NodeGroup]): Box[Seq[NodeInfo]] = {
 
     for {
-      nodes  <- nodeInfoService.getAll()
+      nodes  <- nodeInfoService.getAll().toBox
       setIds =  target match {
                   case Right(nodeGroup) => nodeGroup.serverList
                   case Left(target) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCompliance.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCompliance.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.web.ChooseTemplate
 import com.normation.box._
 import com.normation.errors._
 import com.normation.rudder.services.reports.ReportingServiceUtils
+import com.normation.zio._
 
 object RuleCompliance {
   private def details: NodeSeq = ChooseTemplate(
@@ -217,7 +218,7 @@ class RuleCompliance (
       // here, we don't use the cache because we need to have the details for each change, the cache only provides aggregation
       changesOnRule   <- recentChangesService.getChangesForInterval(rule.id, currentInterval, Some(10000))
       directiveLib    <- getFullDirectiveLib().toBox
-      allNodeInfos    <- getAllNodeInfos()
+      allNodeInfos    <- getAllNodeInfos().toBox
     } yield {
       val changesLine = ChangeLine.jsonByInterval(Map((currentInterval, changesOnRule)), Some(rule.name), directiveLib, allNodeInfos)
       val changesArray = changesLine.in.toList.flatMap{case a:JsArray => a.in.toList; case _ => Nil}
@@ -245,12 +246,12 @@ class RuleCompliance (
   def refreshCompliance() : JsCmd = {
     ( for {
         reports      <- reportingService.findDirectiveRuleStatusReportsByRule(rule.id)
-        allRules     <- roRuleRepository.getAll().toBox
-        groups       <- getGroups().toBox
-        updatedRule  <- allRules.find(_.id == rule.id).notOptional(s"The rule '${rule.id}' is missing").toBox
-        directiveLib <- getFullDirectiveLib().toBox
+        allRules     <- roRuleRepository.getAll()
+        groups       <- getGroups()
+        updatedRule  <- allRules.find(_.id == rule.id).notOptional(s"The rule '${rule.id}' is missing")
+        directiveLib <- getFullDirectiveLib()
         allNodeInfos <- getAllNodeInfos()
-        globalMode   <- configService.rudder_global_policy_mode().toBox
+        globalMode   <- configService.rudder_global_policy_mode()
       } yield {
 
         val ruleReport = ReportingServiceUtils.buildRuleStatusReport(rule.id, reports)
@@ -262,11 +263,11 @@ class RuleCompliance (
           createTooltip();
         """)
       }
-    ) match {
-        case Full(cmd) => cmd
-        case eb : EmptyBox =>
-          val fail = eb ?~! s"Error while computing Rule ${rule.name} (${rule.id.value})"
-          logger.error(fail.messageChain)
+    ).either.runNow match {
+        case Right(cmd) => cmd
+        case Left(err) =>
+          val fail = s"Error while computing Rule ${rule.name} (${rule.id.value}): ${err.fullMsg}"
+          logger.error(fail)
           Noop
       }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -155,7 +155,7 @@ class RuleEditForm(
   private[this] val boxRootRuleCategory = getRootRuleCategory()
 
   private[this] def showForm(idToScroll  : String = "editRuleZonePortlet") : NodeSeq = {
-    (getFullNodeGroupLib().toBox, getFullDirectiveLib().toBox, getAllNodeInfos(), boxRootRuleCategory.toBox, configService.rudder_global_policy_mode().toBox) match {
+    (getFullNodeGroupLib().toBox, getFullDirectiveLib().toBox, getAllNodeInfos().toBox, boxRootRuleCategory.toBox, configService.rudder_global_policy_mode().toBox) match {
       case (Full(groupLib), Full(directiveLib), Full(nodeInfos), Full(rootRuleCategory), Full(globalMode)) =>
 
         val form = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -466,8 +466,8 @@ object DisplayNode extends Loggable {
               }
               val nodeId      = sm.node.main.id
               val publicKeyId = s"publicKey-${nodeId.value}"
-              val cfKeyHash   = nodeInfoService.getNodeInfo(nodeId) match {
-                case Full(Some(nodeInfo)) if(nodeInfo.keyHashCfengine.nonEmpty) => <div><label>Key hash:</label> <samp>{nodeInfo.keyHashCfengine}</samp></div>
+              val cfKeyHash   = nodeInfoService.getNodeInfo(nodeId).either.runNow match {
+                case Right(Some(nodeInfo)) if(nodeInfo.keyHashCfengine.nonEmpty) => <div><label>Key hash:</label> <samp>{nodeInfo.keyHashCfengine}</samp></div>
                 case _                                                            => NodeSeq.Empty
               }
 
@@ -535,9 +535,9 @@ object DisplayNode extends Loggable {
     val nodeId = sm.node.main.id
     inventoryStatus match {
       case AcceptedInventory =>
-        val nodeInfoBox = nodeInfoService.getNodeInfo(nodeId)
+        val nodeInfoBox = nodeInfoService.getNodeInfo(nodeId).either.runNow
         nodeInfoBox match {
-          case Full(Some(nodeInfo)) =>
+          case Right(Some(nodeInfo)) =>
             val kind = {
               if(nodeInfo.isPolicyServer) {
                 if(isRootNode(nodeId) ) {
@@ -560,12 +560,12 @@ object DisplayNode extends Loggable {
             }
 
             <div><label>Role:</label> Rudder {kind} {roles}</div>
-          case Full(None) =>
+          case Right(None) =>
             logger.error(s"Could not fetch node details for node with id ${sm.node.main.id}")
             <div class="error"><label>Role:</label> Could not fetch Role for this node</div>
-          case eb:EmptyBox =>
-            val e = eb ?~! s"Could not fetch node details for node with id ${sm.node.main.id}"
-            logger.error(e.messageChain)
+          case Left(err) =>
+            val e = s"Could not fetch node details for node with id ${sm.node.main.id}: ${err.fullMsg}"
+            logger.error(e)
             <div class="error"><label>Role:</label> Could not fetch Role for this node</div>
         }
       case RemovedInventory =>
@@ -576,14 +576,14 @@ object DisplayNode extends Loggable {
   }
 
   private def displayPolicyServerInfos(sm:FullInventory) : NodeSeq = {
-    nodeInfoService.getNodeInfo(sm.node.main.policyServerId) match {
-      case eb:EmptyBox =>
-        val e = eb ?~! s"Could not fetch policy server details (id '${sm.node.main.policyServerId.value}') for node '${sm.node.main.hostname}' ('${sm.node.main.id.value}')"
-        logger.error(e.messageChain)
+    nodeInfoService.getNodeInfo(sm.node.main.policyServerId).either.runNow match {
+      case Left(err) =>
+        val e = s"Could not fetch policy server details (id '${sm.node.main.policyServerId.value}') for node '${sm.node.main.hostname}' ('${sm.node.main.id.value}'): ${err.fullMsg}"
+        logger.error(e)
         <div class="error"><label>Policy Server:</label> Could not fetch details about the policy server</div>
-      case Full(Some(policyServerDetails)) =>
+      case Right(Some(policyServerDetails)) =>
         <div><label>Policy Server:</label> <a href={linkUtil.baseNodeLink(policyServerDetails.id)}  onclick={s"updateNodeIdAndReload('${policyServerDetails.id.value}')"}>{policyServerDetails.hostname}</a></div>
-      case Full(None) =>
+      case Right(None) =>
         logger.error(s"Could not fetch policy server details (id '${sm.node.main.policyServerId.value}') for node '${sm.node.main.hostname}' ('${sm.node.main.id.value}')")
         <div class="error"><label>Policy Server:</label> Could not fetch details about the policy server</div>
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -123,7 +123,7 @@ object HomePage {
   def initNodeInfos(): Box[Map[NodeId, NodeInfo]] = {
     TimingDebugLogger.debug(s"Start timing homepage")
     val n1 = System.currentTimeMillis
-    val n = nodeInfosService.getAll()
+    val n = nodeInfosService.getAll().toBox
     val n2 = System.currentTimeMillis
     TimingDebugLogger.debug(s"Getting node infos: ${n2 - n1}ms")
     n


### PR DESCRIPTION
Don't be afraid by the line count, most change are just adding or removing `toBox`, `toIO`, or changing pattern matching on `Box` to patter matching on `IOResult(...).either.runNow, logger into pure logger, and `t = System.currentTimeMillis()` into `t <- currentTimeMillis`

The interesting part is in NodeConfigurationService.scala . 

I propose the following changes:
- use a `Ref` for cache. It makes clearer that action on cache must be atomic and generally goes well with `IOResult` type,
- merge `mergeDataFromDBWithCache` with `getCurrentExpectedReports` because it's used only there, and splitting it appart hides several asumption or constraints (be in semaphore, cache data are already there, 
- split CacheComplianceQueueAction to have only action on node expected report cache appart 
